### PR TITLE
Add assignee filtering (only active and undeleted) in get issue details

### DIFF
--- a/apiserver/plane/api/views/issue.py
+++ b/apiserver/plane/api/views/issue.py
@@ -17,6 +17,7 @@ from django.db.models import (
     Value,
     When,
     Subquery,
+    Prefetch,
 )
 from django.utils import timezone
 from django.shortcuts import get_object_or_404
@@ -57,7 +58,8 @@ from plane.db.models import (
     IssueType,
     IssueCustomProperty,
     IssueTypeCustomProperty,
-    Workspace
+    Workspace,
+    User
 )
 from plane.utils.issue_filters import issue_filters
 from .base import BaseAPIView
@@ -193,6 +195,14 @@ class IssueAPIEndpoint(BaseAPIView):
                 .order_by()
                 .annotate(count=Func(F("id"), function="Count"))
                 .values("count")
+            ).prefetch_related(
+                Prefetch(
+                    "assignees",
+                    queryset=User.objects.filter(
+                        member_project__is_active=True,
+                        issue_assignee__deleted_at__isnull=True,
+                    ).distinct()
+                )
             ).get(workspace__slug=slug, project_id=project_id, pk=pk)
             return Response(
                 IssueSerializer(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved issue details to display only currently active and non-deleted assignees when viewing a single issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->