### PR TITLE
Add pt translations for date filters

### DIFF
--- a/packages/i18n/src/locales/pt/translations.json
+++ b/packages/i18n/src/locales/pt/translations.json
@@ -469,5 +469,9 @@
   "assigned_to": "Atribuído a",
   "due_by": "Devido até",
   "blocked_by": "Bloqueado por",
-  "sub_issues": "Subproblemas"
+  "sub_issues": "Subproblemas",
+  "1 week from now": "1 semana atrás",
+  "2 weeks from now": "2 semanas atrás",
+  "1 month from now": "1 mês atrás",
+  "2 months from now": "2 mês atrás"
 }

--- a/web/core/components/cycles/applied-filters/date.tsx
+++ b/web/core/components/cycles/applied-filters/date.tsx
@@ -4,6 +4,7 @@ import { X } from "lucide-react";
 import { DATE_AFTER_FILTER_OPTIONS } from "@/constants/filters";
 import { renderFormattedDate } from "@/helpers/date-time.helper";
 import { capitalizeFirstLetter } from "@/helpers/string.helper";
+import { useTranslation } from "@plane/i18n";
 // constants
 
 type Props = {
@@ -14,13 +15,14 @@ type Props = {
 
 export const AppliedDateFilters: React.FC<Props> = observer((props) => {
   const { editable, handleRemove, values } = props;
+  const { t } = useTranslation();
 
   const getDateLabel = (value: string): string => {
     let dateLabel = "";
 
     const dateDetails = DATE_AFTER_FILTER_OPTIONS.find((d) => d.value === value);
 
-    if (dateDetails) dateLabel = dateDetails.name;
+    if (dateDetails) dateLabel = t(dateDetails.name);
     else {
       const dateParts = value.split(";");
 

--- a/web/core/components/cycles/dropdowns/filters/end-date.tsx
+++ b/web/core/components/cycles/dropdowns/filters/end-date.tsx
@@ -8,6 +8,7 @@ import { FilterHeader, FilterOption } from "@/components/issues";
 import { DATE_AFTER_FILTER_OPTIONS } from "@/constants/filters";
 // helpers
 import { isInDateFormat } from "@/helpers/date-time.helper";
+import { useTranslation } from "@plane/i18n";
 
 type Props = {
   appliedFilters: string[] | null;
@@ -17,6 +18,7 @@ type Props = {
 
 export const FilterEndDate: React.FC<Props> = observer((props) => {
   const { appliedFilters, handleUpdate, searchQuery } = props;
+  const { t } = useTranslation();
 
   const [previewEnabled, setPreviewEnabled] = useState(true);
   const [isDateFilterModalOpen, setIsDateFilterModalOpen] = useState(false);
@@ -62,7 +64,7 @@ export const FilterEndDate: React.FC<Props> = observer((props) => {
                   key={option.value}
                   isChecked={appliedFilters?.includes(option.value) ? true : false}
                   onClick={() => handleUpdate(option.value)}
-                  title={option.name}
+                  title={t(option.name)}
                   multiple
                 />
               ))}

--- a/web/core/components/cycles/dropdowns/filters/start-date.tsx
+++ b/web/core/components/cycles/dropdowns/filters/start-date.tsx
@@ -8,6 +8,7 @@ import { FilterHeader, FilterOption } from "@/components/issues";
 import { DATE_AFTER_FILTER_OPTIONS } from "@/constants/filters";
 // helpers
 import { isInDateFormat } from "@/helpers/date-time.helper";
+import { useTranslation } from "@plane/i18n";
 
 type Props = {
   appliedFilters: string[] | null;
@@ -17,6 +18,7 @@ type Props = {
 
 export const FilterStartDate: React.FC<Props> = observer((props) => {
   const { appliedFilters, handleUpdate, searchQuery } = props;
+  const { t } = useTranslation();
 
   const [previewEnabled, setPreviewEnabled] = useState(true);
   const [isDateFilterModalOpen, setIsDateFilterModalOpen] = useState(false);
@@ -62,7 +64,7 @@ export const FilterStartDate: React.FC<Props> = observer((props) => {
                   key={option.value}
                   isChecked={appliedFilters?.includes(option.value) ? true : false}
                   onClick={() => handleUpdate(option.value)}
-                  title={option.name}
+                  title={t(option.name)}
                   multiple
                 />
               ))}

--- a/web/core/components/issues/issue-layouts/filters/applied-filters/date.tsx
+++ b/web/core/components/issues/issue-layouts/filters/applied-filters/date.tsx
@@ -5,6 +5,7 @@ import { X } from "lucide-react";
 import { DATE_AFTER_FILTER_OPTIONS } from "@/constants/filters";
 import { renderFormattedDate } from "@/helpers/date-time.helper";
 import { capitalizeFirstLetter } from "@/helpers/string.helper";
+import { useTranslation } from "@plane/i18n";
 // constants
 
 type Props = {
@@ -14,13 +15,14 @@ type Props = {
 
 export const AppliedDateFilters: React.FC<Props> = observer((props) => {
   const { handleRemove, values } = props;
+  const { t } = useTranslation();
 
   const getDateLabel = (value: string): string => {
     let dateLabel = "";
 
     const dateDetails = DATE_AFTER_FILTER_OPTIONS.find((d) => d.value === value);
 
-    if (dateDetails) dateLabel = dateDetails.name;
+    if (dateDetails) dateLabel = t(dateDetails.name);
     else {
       const dateParts = value.split(";");
 

--- a/web/core/components/issues/issue-layouts/filters/header/filters/start-date.tsx
+++ b/web/core/components/issues/issue-layouts/filters/header/filters/start-date.tsx
@@ -62,7 +62,7 @@ export const FilterStartDate: React.FC<Props> = observer((props) => {
                   key={option.value}
                   isChecked={appliedFilters?.includes(option.value) ? true : false}
                   onClick={() => handleUpdate(option.value)}
-                  title={option.name}
+                  title={t(option.name)}
                   multiple
                 />
               ))}

--- a/web/core/components/issues/issue-layouts/filters/header/filters/target-date.tsx
+++ b/web/core/components/issues/issue-layouts/filters/header/filters/target-date.tsx
@@ -62,7 +62,7 @@ export const FilterTargetDate: React.FC<Props> = observer((props) => {
                   key={option.value}
                   isChecked={appliedFilters?.includes(option.value) ? true : false}
                   onClick={() => handleUpdate(option.value)}
-                  title={option.name}
+                  title={t(option.name)}
                   multiple
                 />
               ))}

--- a/web/core/components/modules/applied-filters/date.tsx
+++ b/web/core/components/modules/applied-filters/date.tsx
@@ -5,6 +5,7 @@ import { X } from "lucide-react";
 import { DATE_AFTER_FILTER_OPTIONS } from "@/constants/filters";
 import { renderFormattedDate } from "@/helpers/date-time.helper";
 import { capitalizeFirstLetter } from "@/helpers/string.helper";
+import { useTranslation } from "@plane/i18n";
 // constants
 
 type Props = {
@@ -15,13 +16,14 @@ type Props = {
 
 export const AppliedDateFilters: React.FC<Props> = observer((props) => {
   const { editable, handleRemove, values } = props;
+  const { t } = useTranslation();
 
   const getDateLabel = (value: string): string => {
     let dateLabel = "";
 
     const dateDetails = DATE_AFTER_FILTER_OPTIONS.find((d) => d.value === value);
 
-    if (dateDetails) dateLabel = dateDetails.name;
+    if (dateDetails) dateLabel = t(dateDetails.name);
     else {
       const dateParts = value.split(";");
 

--- a/web/core/components/modules/dropdowns/filters/start-date.tsx
+++ b/web/core/components/modules/dropdowns/filters/start-date.tsx
@@ -8,6 +8,7 @@ import { FilterHeader, FilterOption } from "@/components/issues";
 import { DATE_AFTER_FILTER_OPTIONS } from "@/constants/filters";
 // helpers
 import { isInDateFormat } from "@/helpers/date-time.helper";
+import { useTranslation } from "@plane/i18n";
 
 type Props = {
   appliedFilters: string[] | null;
@@ -17,6 +18,7 @@ type Props = {
 
 export const FilterStartDate: React.FC<Props> = observer((props) => {
   const { appliedFilters, handleUpdate, searchQuery } = props;
+  const { t } = useTranslation();
 
   const [previewEnabled, setPreviewEnabled] = useState(true);
   const [isDateFilterModalOpen, setIsDateFilterModalOpen] = useState(false);
@@ -62,7 +64,7 @@ export const FilterStartDate: React.FC<Props> = observer((props) => {
                   key={option.value}
                   isChecked={appliedFilters?.includes(option.value) ? true : false}
                   onClick={() => handleUpdate(option.value)}
-                  title={option.name}
+                  title={t(option.name)}
                   multiple
                 />
               ))}

--- a/web/core/components/modules/dropdowns/filters/target-date.tsx
+++ b/web/core/components/modules/dropdowns/filters/target-date.tsx
@@ -8,6 +8,7 @@ import { FilterHeader, FilterOption } from "@/components/issues";
 import { DATE_AFTER_FILTER_OPTIONS } from "@/constants/filters";
 // helpers
 import { isInDateFormat } from "@/helpers/date-time.helper";
+import { useTranslation } from "@plane/i18n";
 
 type Props = {
   appliedFilters: string[] | null;
@@ -17,6 +18,7 @@ type Props = {
 
 export const FilterTargetDate: React.FC<Props> = observer((props) => {
   const { appliedFilters, handleUpdate, searchQuery } = props;
+  const { t } = useTranslation();
 
   const [previewEnabled, setPreviewEnabled] = useState(true);
   const [isDateFilterModalOpen, setIsDateFilterModalOpen] = useState(false);
@@ -62,7 +64,7 @@ export const FilterTargetDate: React.FC<Props> = observer((props) => {
                   key={option.value}
                   isChecked={appliedFilters?.includes(option.value) ? true : false}
                   onClick={() => handleUpdate(option.value)}
-                  title={option.name}
+                  title={t(option.name)}
                   multiple
                 />
               ))}


### PR DESCRIPTION
## Summary
- translate 'DATE_AFTER_FILTER_OPTIONS' labels to Portuguese
- show translations on date filter dropdowns

## Testing
- `yarn lint` *(fails: unable to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_b_68831d41daf88329993bdeac4030adf9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Portuguese translations for relative time expressions such as "1 week ago", "2 weeks ago", "1 month ago", and "2 months ago".

* **Enhancements**
  * Improved internationalization across various date filter components, ensuring filter option labels and applied filter descriptions are now displayed in the user's selected language. 

* **Bug Fixes**
  * Corrected display of filter option titles to use localized text instead of raw strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->