### PR TITLE
Add translation hook for Views

### DIFF
--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/views/(list)/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/views/(list)/header.tsx
@@ -43,7 +43,7 @@ export const ProjectViewsHeader = observer(() => {
             />
             <Breadcrumbs.BreadcrumbItem
               type="text"
-              link={<BreadcrumbLink label="Views" icon={<Layers className="h-4 w-4 text-custom-text-300" />} />}
+              link={<BreadcrumbLink label={t("views")} icon={<Layers className="h-4 w-4 text-custom-text-300" />} />}
             />
           </Breadcrumbs>
         </Header.LeftItem>

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/views/(list)/page.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/views/(list)/page.tsx
@@ -17,16 +17,18 @@ import { EViewAccess } from "@/constants/views";
 import { calculateTotalFilters } from "@/helpers/filter.helper";
 // hooks
 import { useProject, useProjectView } from "@/hooks/store";
+import { useTranslation } from "@plane/i18n";
 
 const ProjectViewsPage = observer(() => {
   // router
   const { workspaceSlug, projectId } = useParams();
+  const { t } = useTranslation();
   // store
   const { getProjectById, currentProjectDetails } = useProject();
   const { filters, updateFilters, clearAllFilters } = useProjectView();
   // derived values
   const project = projectId ? getProjectById(projectId.toString()) : undefined;
-  const pageTitle = project?.name ? `${project?.name} - Views` : undefined;
+  const pageTitle = project?.name ? `${project?.name} - ${t("views")}` : undefined;
 
   if (!workspaceSlug || !projectId) return <></>;
 

--- a/web/app/[workspaceSlug]/(projects)/workspace-views/[globalViewId]/page.tsx
+++ b/web/app/[workspaceSlug]/(projects)/workspace-views/[globalViewId]/page.tsx
@@ -10,16 +10,18 @@ import { GlobalViewsHeader } from "@/components/workspace";
 import { DEFAULT_GLOBAL_VIEWS_LIST } from "@/constants/workspace";
 // hooks
 import { useWorkspace } from "@/hooks/store";
+import { useTranslation } from "@plane/i18n";
 
 const GlobalViewIssuesPage = observer(() => {
   // router
   const { globalViewId } = useParams();
   // store hooks
   const { currentWorkspace } = useWorkspace();
+  const { t } = useTranslation();
 
   // derived values
   const defaultView = DEFAULT_GLOBAL_VIEWS_LIST.find((view) => view.key === globalViewId);
-  const pageTitle = currentWorkspace?.name ? `${currentWorkspace?.name} - All Views` : undefined;
+  const pageTitle = currentWorkspace?.name ? `${currentWorkspace?.name} - All ${t("views")}` : undefined;
 
   return (
     <>

--- a/web/app/[workspaceSlug]/(projects)/workspace-views/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/workspace-views/header.tsx
@@ -105,7 +105,7 @@ export const GlobalIssuesHeader = observer(() => {
           <Breadcrumbs>
             <Breadcrumbs.BreadcrumbItem
               type="text"
-              link={<BreadcrumbLink label={`Views`} icon={<Layers className="h-4 w-4 text-custom-text-300" />} />}
+              link={<BreadcrumbLink label={t("views")} icon={<Layers className="h-4 w-4 text-custom-text-300" />} />}
             />
           </Breadcrumbs>
         </Header.LeftItem>

--- a/web/app/[workspaceSlug]/(projects)/workspace-views/page.tsx
+++ b/web/app/[workspaceSlug]/(projects)/workspace-views/page.tsx
@@ -21,7 +21,7 @@ const WorkspaceViewsPage = observer(() => {
   // store
   const { currentWorkspace } = useWorkspace();
   // derived values
-  const pageTitle = currentWorkspace?.name ? `${currentWorkspace?.name} - All Views` : undefined;
+  const pageTitle = currentWorkspace?.name ? `${currentWorkspace?.name} - All ${t("views")}` : undefined;
 
   return (
     <>

--- a/web/core/components/command-palette/actions/search-results.tsx
+++ b/web/core/components/command-palette/actions/search-results.tsx
@@ -8,6 +8,7 @@ import { IWorkspaceSearchResults } from "@plane/types";
 import { commandGroups } from "@/components/command-palette";
 // hooks
 import { useAppRouter } from "@/hooks/use-app-router";
+import { useTranslation } from "@plane/i18n";
 
 type Props = {
   closePalette: () => void;
@@ -19,6 +20,7 @@ export const CommandPaletteSearchResults: React.FC<Props> = (props) => {
   // router
   const router = useAppRouter();
   const { projectId: routerProjectId } = useParams();
+  const { t } = useTranslation();
   // derived values
   const projectId = routerProjectId?.toString();
 
@@ -30,7 +32,10 @@ export const CommandPaletteSearchResults: React.FC<Props> = (props) => {
 
         if (section.length > 0) {
           return (
-            <Command.Group key={key} heading={`${currentSection.title} search`}>
+            <Command.Group
+              key={key}
+              heading={`${key === "issue_view" ? t("views") : currentSection.title} search`}
+            >
               {section.map((item: any) => (
                 <Command.Item
                   key={item.id}

--- a/web/core/components/project/publish-project/modal.tsx
+++ b/web/core/components/project/publish-project/modal.tsx
@@ -14,6 +14,7 @@ import { SPACE_BASE_PATH, SPACE_BASE_URL } from "@/helpers/common.helper";
 import { copyTextToClipboard } from "@/helpers/string.helper";
 // hooks
 import { useProjectPublish } from "@/hooks/store";
+import { useTranslation } from "@plane/i18n";
 
 type Props = {
   isOpen: boolean;
@@ -55,6 +56,7 @@ export const PublishProjectModal: React.FC<Props> = observer((props) => {
     unPublishProject,
     fetchSettingsLoader,
   } = useProjectPublish();
+  const { t } = useTranslation();
   // derived values
   const projectPublishSettings = getPublishSettingsByProjectID(project.id);
   // form info
@@ -230,7 +232,7 @@ export const PublishProjectModal: React.FC<Props> = observer((props) => {
             )}
             <div className="space-y-4">
               <div className="relative flex items-center justify-between gap-2">
-                <div className="text-sm">Views</div>
+                <div className="text-sm">{t("views")}</div>
                 <Controller
                   control={control}
                   name="view_props"


### PR DESCRIPTION
## Summary
- internationalize the `Views` label in multiple components
- translate project publish modal label
- internationalize headings in command palette search results

## Testing
- `yarn lint` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_68836a8717d88329b0db19f6e26339d2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internationalization support for the "Views" label across various pages, headers, modals, breadcrumbs, and command palette sections. The label now displays in the user's selected language instead of being fixed in English.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->