### PR TITLE
Implement Portuguese translations for issue priority labels

### DIFF
--- a/space/core/components/issues/filters/priority.tsx
+++ b/space/core/components/issues/filters/priority.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import { observer } from "mobx-react";
 // ui
+import { useTranslation } from "@plane/i18n";
 import { PriorityIcon } from "@plane/ui";
 // components
 import { issuePriorityFilters } from "@/constants/issue";
@@ -17,6 +18,7 @@ type Props = {
 
 export const FilterPriority: React.FC<Props> = observer((props) => {
   const { appliedFilters, handleUpdate, searchQuery } = props;
+  const { t } = useTranslation();
 
   const [previewEnabled, setPreviewEnabled] = useState(true);
 
@@ -27,7 +29,7 @@ export const FilterPriority: React.FC<Props> = observer((props) => {
   return (
     <>
       <FilterHeader
-        title={`Priority${appliedFiltersCount > 0 ? ` (${appliedFiltersCount})` : ""}`}
+        title={`${t("priority")}${appliedFiltersCount > 0 ? ` (${appliedFiltersCount})` : ""}`}
         isPreviewEnabled={previewEnabled}
         handleIsPreviewEnabled={() => setPreviewEnabled(!previewEnabled)}
       />
@@ -40,11 +42,11 @@ export const FilterPriority: React.FC<Props> = observer((props) => {
                 isChecked={appliedFilters?.includes(priority.key) ? true : false}
                 onClick={() => handleUpdate(priority.key)}
                 icon={<PriorityIcon priority={priority.key} className="h-3.5 w-3.5" />}
-                title={priority.title}
+                title={t(priority.key)}
               />
             ))
           ) : (
-            <p className="text-xs italic text-custom-text-400">No matches found</p>
+            <p className="text-xs italic text-custom-text-400">{t("no_matches_found")}</p>
           )}
         </div>
       )}

--- a/web/core/components/command-palette/actions/issue-actions/change-priority.tsx
+++ b/web/core/components/command-palette/actions/issue-actions/change-priority.tsx
@@ -5,6 +5,7 @@ import { observer } from "mobx-react";
 import { useParams } from "next/navigation";
 import { Check } from "lucide-react";
 import { TIssue, TIssuePriorities } from "@plane/types";
+import { useTranslation } from "@plane/i18n";
 // mobx store
 import { PriorityIcon } from "@plane/ui";
 import { EIssuesStoreType, ISSUE_PRIORITIES } from "@/constants/issue";
@@ -22,6 +23,7 @@ export const ChangeIssuePriority: React.FC<Props> = observer((props) => {
   const { closePalette, issue } = props;
   // router params
   const { workspaceSlug, projectId } = useParams();
+  const { t } = useTranslation();
   const {
     issues: { updateIssue },
   } = useIssues(EIssuesStoreType.PROJECT);
@@ -46,7 +48,7 @@ export const ChangeIssuePriority: React.FC<Props> = observer((props) => {
         <Command.Item key={priority.key} onSelect={() => handleIssueState(priority.key)} className="focus:outline-none">
           <div className="flex items-center space-x-3">
             <PriorityIcon priority={priority.key} />
-            <span className="capitalize">{priority.title ?? "None"}</span>
+            <span className="capitalize">{t(priority.key)}</span>
           </div>
           <div>{priority.key === issue.priority && <Check className="h-3 w-3" />}</div>
         </Command.Item>

--- a/web/core/components/inbox/inbox-filter/applied-filters/priority.tsx
+++ b/web/core/components/inbox/inbox-filter/applied-filters/priority.tsx
@@ -4,6 +4,7 @@ import { FC } from "react";
 import { observer } from "mobx-react";
 import { X } from "lucide-react";
 import { TIssuePriorities } from "@plane/types";
+import { useTranslation } from "@plane/i18n";
 import { PriorityIcon, Tag } from "@plane/ui";
 // constants
 import { ISSUE_PRIORITIES } from "@/constants/issue";
@@ -12,6 +13,7 @@ import { useProjectInbox } from "@/hooks/store";
 
 export const InboxIssueAppliedFiltersPriority: FC = observer(() => {
   // hooks
+  const { t } = useTranslation();
   const { inboxFilters, handleInboxIssueFilters } = useProjectInbox();
   // derived values
   const filteredValues = inboxFilters?.priority || [];
@@ -26,7 +28,7 @@ export const InboxIssueAppliedFiltersPriority: FC = observer(() => {
   if (filteredValues.length === 0) return <></>;
   return (
     <Tag>
-      <div className="text-xs text-custom-text-200">Priority</div>
+      <div className="text-xs text-custom-text-200">{t("priority")}</div>
       {filteredValues.map((value) => {
         const optionDetail = currentOptionDetail(value);
         if (!optionDetail) return <></>;
@@ -35,7 +37,7 @@ export const InboxIssueAppliedFiltersPriority: FC = observer(() => {
             <div className="w-3 h-3 flex-shrink-0 relative flex justify-center items-center overflow-hidden">
               <PriorityIcon priority={optionDetail.key} className="h-3 w-3" />
             </div>
-            <div className="text-xs truncate">{optionDetail?.title}</div>
+            <div className="text-xs truncate">{t(optionDetail.key)}</div>
             <div
               className="w-3 h-3 flex-shrink-0 relative flex justify-center items-center overflow-hidden cursor-pointer text-custom-text-300 hover:text-custom-text-200 transition-all"
               onClick={() => handleInboxIssueFilters("priority", handleFilterValue(optionDetail?.key))}

--- a/web/core/components/inbox/inbox-filter/filters/priority.tsx
+++ b/web/core/components/inbox/inbox-filter/filters/priority.tsx
@@ -3,6 +3,7 @@
 import { FC, useState } from "react";
 import { observer } from "mobx-react";
 import { TIssuePriorities } from "@plane/types";
+import { useTranslation } from "@plane/i18n";
 import { PriorityIcon } from "@plane/ui";
 // components
 import { FilterHeader, FilterOption } from "@/components/issues";
@@ -18,6 +19,7 @@ type Props = {
 export const FilterPriority: FC<Props> = observer((props) => {
   const { searchQuery } = props;
   // hooks
+  const { t } = useTranslation();
   const { inboxFilters, handleInboxIssueFilters } = useProjectInbox();
   // states
   const [previewEnabled, setPreviewEnabled] = useState(true);
@@ -32,7 +34,7 @@ export const FilterPriority: FC<Props> = observer((props) => {
   return (
     <>
       <FilterHeader
-        title={`Priority${appliedFiltersCount > 0 ? ` (${appliedFiltersCount})` : ""}`}
+        title={`${t("priority")}${appliedFiltersCount > 0 ? ` (${appliedFiltersCount})` : ""}`}
         isPreviewEnabled={previewEnabled}
         handleIsPreviewEnabled={() => setPreviewEnabled(!previewEnabled)}
       />
@@ -45,11 +47,11 @@ export const FilterPriority: FC<Props> = observer((props) => {
                 isChecked={filterValue?.includes(priority.key) ? true : false}
                 onClick={() => handleInboxIssueFilters("priority", handleFilterValue(priority.key))}
                 icon={<PriorityIcon priority={priority.key} className="h-3.5 w-3.5" />}
-                title={priority.title}
+                title={t(priority.key)}
               />
             ))
           ) : (
-            <p className="text-xs italic text-custom-text-400">No matches found</p>
+            <p className="text-xs italic text-custom-text-400">{t("no_matches_found")}</p>
           )}
         </div>
       )}

--- a/web/core/components/issues/issue-layouts/filters/header/filters/priority.tsx
+++ b/web/core/components/issues/issue-layouts/filters/header/filters/priority.tsx
@@ -45,7 +45,7 @@ export const FilterPriority: React.FC<Props> = observer((props) => {
                 isChecked={appliedFilters?.includes(priority.key) ? true : false}
                 onClick={() => handleUpdate(priority.key)}
                 icon={<PriorityIcon priority={priority.key} className="h-3.5 w-3.5" />}
-                title={priority.title}
+                title={t(priority.key)}
               />
             ))
           ) : (

--- a/web/core/components/issues/issue-layouts/kanban/headers/group-by-card.tsx
+++ b/web/core/components/issues/issue-layouts/kanban/headers/group-by-card.tsx
@@ -7,6 +7,7 @@ import { useParams, usePathname } from "next/navigation";
 import { Minimize2, Maximize2, Circle, Plus } from "lucide-react";
 import { TIssue, ISearchIssueResponse, TIssueKanbanFilters, TIssueGroupByOptions } from "@plane/types";
 // ui
+import { useTranslation } from "@plane/i18n";
 import { CustomMenu, TOAST_TYPE, setToast } from "@plane/ui";
 // components
 import { ExistingIssuesListModal } from "@/components/core";
@@ -44,6 +45,7 @@ export const HeaderGroupByCard: FC<IHeaderGroupByCard> = observer((props) => {
     disableIssueCreation,
     addIssuesToView,
   } = props;
+  const { t } = useTranslation();
   const verticalAlignPosition = sub_group_by ? false : collapsedGroups?.group_by.includes(column_id);
   // states
   const [isOpen, setIsOpen] = React.useState(false);
@@ -121,7 +123,7 @@ export const HeaderGroupByCard: FC<IHeaderGroupByCard> = observer((props) => {
               verticalAlignPosition ? `vertical-lr max-h-[400px]` : ``
             }`}
           >
-            {title}
+            {(group_by === "priority" || sub_group_by === "priority") ? t(column_id) : title}
           </div>
           <div
             className={`flex-shrink-0 text-sm font-medium text-custom-text-300 ${verticalAlignPosition ? `pr-0.5` : `pl-2`}`}

--- a/web/core/components/issues/issue-layouts/list/headers/group-by-card.tsx
+++ b/web/core/components/issues/issue-layouts/list/headers/group-by-card.tsx
@@ -7,6 +7,7 @@ import { CircleDashed, Plus } from "lucide-react";
 // types
 import { TIssue, ISearchIssueResponse } from "@plane/types";
 // ui
+import { useTranslation } from "@plane/i18n";
 import { CustomMenu, TOAST_TYPE, setToast } from "@plane/ui";
 // components
 import { ExistingIssuesListModal, MultipleSelectGroupAction } from "@/components/core";
@@ -45,6 +46,7 @@ export const HeaderGroupByCard = observer((props: IHeaderGroupByCard) => {
     selectionHelpers,
     handleCollapsedGroups
   } = props;
+  const { t } = useTranslation();
   // states
   const [isOpen, setIsOpen] = useState(false);
   const [openExistingIssueListModal, setOpenExistingIssueListModal] = useState(false);
@@ -110,7 +112,7 @@ export const HeaderGroupByCard = observer((props: IHeaderGroupByCard) => {
           className="relative flex w-full flex-row items-center gap-1 overflow-hidden cursor-pointer"
           onClick={() => handleCollapsedGroups(groupID)}
         >
-          <div className="inline-block line-clamp-1 truncate font-medium text-custom-text-100">{title}</div>
+          <div className="inline-block line-clamp-1 truncate font-medium text-custom-text-100">{["urgent","high","medium","low","none"].includes(groupID) ? t(groupID) : title}</div>
           <div className="pl-2 text-sm font-medium text-custom-text-300">{count || 0}</div>
         </div>
 


### PR DESCRIPTION
## Summary
- localize priority dropdowns and filters using `useTranslation`
- show translated priority names in kanban/list headers

## Testing
- `yarn lint` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68864f47b2908329bf7baccf02997c99