### PR TITLE
[Production] Add limit to unread notification count - ISS-274914

### DIFF
--- a/apiserver/plane/app/views/notification/base.py
+++ b/apiserver/plane/app/views/notification/base.py
@@ -250,7 +250,7 @@ class UnreadNotificationEndpoint(BaseAPIView):
     )
     def get(self, request, slug):
         # Watching Issues Count
-        unread_notifications_count = (
+        unread_notifications_count = len(
             Notification.objects.filter(
                 workspace__slug=slug,
                 receiver_id=request.user.id,
@@ -258,18 +258,19 @@ class UnreadNotificationEndpoint(BaseAPIView):
                 archived_at__isnull=True,
                 snoozed_till__isnull=True,
             )
-            .exclude(sender__icontains="mentioned")
-            .count()
+            .exclude(sender__icontains="mentioned")[:100]
         )
 
-        mention_notifications_count = Notification.objects.filter(
-            workspace__slug=slug,
-            receiver_id=request.user.id,
-            read_at__isnull=True,
-            archived_at__isnull=True,
-            snoozed_till__isnull=True,
-            sender__icontains="mentioned",
-        ).count()
+        mention_notifications_count = len(
+            Notification.objects.filter(
+                workspace__slug=slug,
+                receiver_id=request.user.id,
+                read_at__isnull=True,
+                archived_at__isnull=True,
+                snoozed_till__isnull=True,
+                sender__icontains="mentioned",
+            )[:100]
+        )
 
         return Response(
             {


### PR DESCRIPTION
## Description
This PR adds a limit to the unread notification count query to improve performance and prevent potential issues with large datasets.

## Changes
- Added limit in the query count for unread notifications
- This is a production deployment of the fix for ISS-274914

## Testing
- [ ] Tested on staging environment
- [ ] Verified notification count limits work correctly
- [ ] Performance testing completed

## Related Issue
ISS-274914

## Deployment Target
Production Environment

## Pre-deployment Checklist
- [ ] Staging PR has been tested and approved
- [ ] All tests passing
- [ ] Performance impact assessed
- [ ] Rollback plan prepared

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized notification counting to improve responsiveness.

* **Bug Fixes**
  * Unread notification count is now capped at a maximum of 100 in responses.
  * Mention notification count is now capped at a maximum of 100 in responses.

* **Documentation**
  * Clarified behavior that notification counts reflect a maximum of 100 items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->