### PR TITLE
[Hotfix] ]Prod] Return attachment url instead of http redirect

### DIFF
--- a/apiserver/plane/api/views/attachment.py
+++ b/apiserver/plane/api/views/attachment.py
@@ -126,7 +126,12 @@ class IssueAttachmentV2Endpoint(BaseAPIView):
                 disposition="attachment",
                 filename=asset.attributes.get("name"),
             )
-            return HttpResponseRedirect(presigned_url)
+            data = {
+                "url": presigned_url,
+                "type": asset.attributes.get("type"),
+                "name": asset.attributes.get("name"),
+            }
+            return Response(data, status=status.HTTP_200_OK)
 
         # Get all the attachments
         issue_attachments = FileAsset.objects.filter(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Issue attachment retrieval now returns a JSON response with a presigned download URL plus asset metadata (type and name), instead of redirecting. This simplifies client handling and enables easier access to attachment details while keeping the same 200 OK status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->