### PR TITLE
[Hot-Fix] ISS-285241: Add username field to member API response

### DIFF
--- a/apiserver/plane/api/serializers/user.py
+++ b/apiserver/plane/api/serializers/user.py
@@ -15,6 +15,7 @@ class UserLiteSerializer(BaseSerializer):
             "avatar",
             "avatar_url",
             "display_name",
+            "username",
             "hub_codes",
             "hub_names",
             "is_super_admin",


### PR DESCRIPTION
## Summary

- The `UserLiteSerializer` used by the `/api/v1/.../members/` endpoint was missing the `username` field, causing the ticketing-tool's `get_project_members` to not receive usernames in the response
- Added `username` to the serializer's fields list so the API now returns it alongside other user fields

## Ticket Information

**Link:** [ISS-285241](https://app.devrev.ai/shipsy/works/ISS-285241)

## How to Test

1. Call `GET /api/v1/workspaces/{slug}/projects/DEFAULT/members/`
2. Verify each member object now includes a `username` field
3. Verify the ticketing-tool's `_resolve_user_identity` correctly parses the username from the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)