### PR TITLE
fix(ISS-288430): null username on assignee user creation breaks ticket master with assignees

### DIFF
--- a/apiserver/plane/api/views/member.py
+++ b/apiserver/plane/api/views/member.py
@@ -143,7 +143,10 @@ class ProjectMemberAPIEndpoint(BaseAPIView):
             )
 
         # Check if user exists
-        user = User.objects.filter(email=email.lower()).first()
+        # Case-insensitive match: existing users may have been stored with
+        # mixed-case emails, and an exact lowercase match would miss them,
+        # sending us into the create path for users that already exist.
+        user = User.objects.filter(email__iexact=email).first()
         workspace_member = None
         project_member = None
 
@@ -172,7 +175,7 @@ class ProjectMemberAPIEndpoint(BaseAPIView):
         )
 
         user_data = {
-                "email": email,
+                "email": email.lower(),
                 "display_name": request.data.get("display_name"),
                 "first_name": request.data.get("first_name", ""),
                 "last_name": request.data.get("last_name", ""),
@@ -298,13 +301,16 @@ class ProjectMemberAPIEndpoint(BaseAPIView):
 
     @staticmethod
     def create_user(data):
+        # data may contain an explicit None for username; dict.get's default
+        # only applies when the key is absent, so fall back with `or`.
+        username = data.get("username") or uuid.uuid4().hex
         user = User.objects.create(
             email=data.get("email"),
             display_name=data.get("display_name"),
             first_name=data.get("first_name", ""),
             last_name=data.get("last_name", ""),
-            username=data.get("username", uuid.uuid4().hex),
-            password=make_password(data.get("username", uuid.uuid4().hex)),
+            username=username,
+            password=make_password(username),
             is_password_autoset=False,
             is_active=True,
             hub_codes=data.get("hub_codes", []),

--- a/apiserver/plane/api/views/ticket_master.py
+++ b/apiserver/plane/api/views/ticket_master.py
@@ -214,7 +214,7 @@ class TicketMasterAPIEndpoint(BaseAPIView):
             # assignee's writes (user / profile / memberships) without
             # poisoning the outer atomic() block.
             with transaction.atomic():
-                user = User.objects.filter(email=email).first()
+                user = User.objects.filter(email__iexact=email).first()
 
                 if not user:
                     user = ProjectMemberAPIEndpoint.create_user(


### PR DESCRIPTION
## Problem
Creating a ticket master **with assignees** fails with a 400 on `POST /api/v1/workspaces/<slug>/projects/<id>/members/`:

```
null value in column "username" of relation "users" violates not-null constraint
```

Ticket master creation **without assignees** works fine — the bug is only in the user-creation path that assignees trigger.

## Root cause
Both callers (`ProjectMemberAPIEndpoint.post` and `TicketMasterAPIEndpoint._resolve_assignees`) build the user dict with the `username` key explicitly present:

```python
"username": request.data.get("username")   # None when not sent
```

In `create_user`, `data.get("username", uuid.uuid4().hex)` never applies its default because `dict.get`'s default only kicks in when the key is **absent** — not when its value is `None`. So `username=None` reaches the INSERT and Postgres rejects it. Broken since `feecd2248` added the username key to the caller dict; every assignee not already present in the Plane DB hits this.

## Fix
- `create_user` computes `username = data.get("username") or uuid.uuid4().hex` and uses the same value for the password (previously two *different* uuids were generated for username vs password)
- Existing-user lookup uses `email__iexact` in both endpoints, so users stored with mixed-case emails resolve instead of falling into the create path
- New users are stored with lowercased email

## Testing
- `python -m py_compile` on both files
- Verified against prod logs (14–15 July, `prod-plane-apiserver-syd`, workspace `ancdeliversuat`): failing rows show `username = null` for assignees absent from the SYD Plane DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)