### PR TITLE
[ISS-290162] fix: new assignees not getting created in Plane

### DIFF
--- a/apiserver/plane/api/views/member.py
+++ b/apiserver/plane/api/views/member.py
@@ -143,7 +143,7 @@ class ProjectMemberAPIEndpoint(BaseAPIView):
             )
 
         # Check if user exists
-        user = User.objects.filter(email=email.lower()).first()
+        user = User.objects.filter(email__iexact=email).first()
         workspace_member = None
         project_member = None
 
@@ -172,7 +172,7 @@ class ProjectMemberAPIEndpoint(BaseAPIView):
         )
 
         user_data = {
-                "email": email,
+                "email": email.lower(),
                 "display_name": request.data.get("display_name"),
                 "first_name": request.data.get("first_name", ""),
                 "last_name": request.data.get("last_name", ""),
@@ -298,13 +298,14 @@ class ProjectMemberAPIEndpoint(BaseAPIView):
 
     @staticmethod
     def create_user(data):
+        username = data.get("username") or uuid.uuid4().hex
         user = User.objects.create(
             email=data.get("email"),
             display_name=data.get("display_name"),
             first_name=data.get("first_name", ""),
             last_name=data.get("last_name", ""),
-            username=data.get("username", uuid.uuid4().hex),
-            password=make_password(data.get("username", uuid.uuid4().hex)),
+            username=username,
+            password=make_password(username),
             is_password_autoset=False,
             is_active=True,
             hub_codes=data.get("hub_codes", []),

--- a/apiserver/plane/api/views/ticket_master.py
+++ b/apiserver/plane/api/views/ticket_master.py
@@ -214,7 +214,7 @@ class TicketMasterAPIEndpoint(BaseAPIView):
             # assignee's writes (user / profile / memberships) without
             # poisoning the outer atomic() block.
             with transaction.atomic():
-                user = User.objects.filter(email=email).first()
+                user = User.objects.filter(email__iexact=email).first()
 
                 if not user:
                     user = ProjectMemberAPIEndpoint.create_user(


### PR DESCRIPTION
## Problem

When a new assignee is added via the consolidated ticket-master flow (or the standalone `POST .../members/` endpoint), the user is never created in Plane — the request fails with a database integrity error.

## Root causes

1. **`username=None` broke every new-user INSERT.** Both callers passed an explicit `"username": None` to `create_user`, and `dict.get("username", uuid_fallback)` only returns the fallback when the key is *absent*, not when its value is `None`. So `User.username` (NOT NULL, unique) received `None` and Postgres rejected the row.

2. **Case-sensitive email lookup pushed existing users into the create path.** Users stored with mixed-case emails weren't found by an exact lowercase match, so the code attempted to re-create them and collided on the unique email constraint.

## Fix

- `create_user` now resolves the username with `data.get("username") or uuid.uuid4().hex`, and uses the same generated value for both username and password (previously two different uuids were generated).
- User lookups in both `ProjectMemberAPIEndpoint.post` and `TicketMasterAPIEndpoint._resolve_assignees` now use `email__iexact`.
- Newly created users store a lowercased email.

## Testing

- Syntax-checked both modified files.
- Repro: POST to `/ticket-master/` with a brand-new assignee email previously returned 400 (NOT NULL violation on `users.username`); with this fix the user + workspace/project memberships are created and returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)