### PR TITLE
Add custom property columns to issue export (download functionality)

### DIFF
--- a/apiserver/plane/bgtasks/export_task.py
+++ b/apiserver/plane/bgtasks/export_task.py
@@ -21,10 +21,12 @@ from plane.db.models import (
     ExporterHistory,
     FileAsset,
     Issue,
+    IssueCustomProperty,
     IssueLink,
     ProjectMember,
     State,
 )
+from plane.utils.constants import ALLOWED_CUSTOM_PROPERTY_WORKSPACE_MAP
 from plane.utils.exception_logger import log_exception
 from plane.utils.issue_filters import (
     apply_user_hub_filters,
@@ -413,6 +415,39 @@ def _introspect_field(key):
 EXCLUDED_EXPORT_KEYS = {"cycle", "modules", "estimate"}
 
 
+# Custom properties live in the `IssueCustomProperty` key/value table, not on
+# `Issue`, so they can't be introspected or joined through `.values(...)`
+# (joining would fan out one row per property, on top of the assignee/label
+# fan-out). Instead we fetch them in one extra query and append them as
+# trailing columns in `generate_csv`.
+def fetch_custom_property_map(issue_ids, keys):
+    """Build `issue_id → {key: cell}` for the given issues, rendering
+    whichever typed value column is populated."""
+    if not keys or not issue_ids:
+        return {}
+    cp_map = {}
+    rows = IssueCustomProperty.objects.filter(
+        issue_id__in=issue_ids,
+        key__in=keys,
+        deleted_at__isnull=True,
+    ).values("issue_id", "key", "value", "int_value", "bool_value", "date_value")
+    for row in rows:
+        if row["value"] not in (None, ""):
+            cell = row["value"]
+        elif row["int_value"] is not None:
+            cell = row["int_value"]
+        elif row["bool_value"] is not None:
+            cell = "Yes" if row["bool_value"] else "No"
+        elif row["date_value"] is not None:
+            cell = dateConverter(row["date_value"])
+        else:
+            cell = ""
+        # Default ordering is -created_at, so the first row seen per
+        # (issue, key) is the most recent one.
+        cp_map.setdefault(row["issue_id"], {}).setdefault(row["key"], cell)
+    return cp_map
+
+
 def resolve_export_columns(display_properties=None):
     """Build the ordered list of `_Resolver` objects for this export.
 
@@ -545,8 +580,12 @@ def _merge_multivalue_cell(existing_cell, incoming_cell):
     return f"{existing}, {incoming}"
 
 
-def generate_csv(header, project_id, issues, files, columns):
-    """Generate CSV export for the passed issues using `columns`.
+def generate_csv(
+    header, project_id, issues, files, columns, custom_keys=(), custom_property_map=None
+):
+    """Generate CSV export for the passed issues using `columns`, plus one
+    trailing column per key in `custom_keys` filled from
+    `custom_property_map` (issue_id → {key: cell}).
 
     Deduplicates M2M fan-out rows (assignees × labels) by issue ID in O(1)
     per input row using a dict keyed on the issue's ID cell.
@@ -554,11 +593,15 @@ def generate_csv(header, project_id, issues, files, columns):
     id_idx = _index_for(columns, "ID")
     assignee_idx = _index_for(columns, "Assignees")
     labels_idx = _index_for(columns, "Labels")
+    custom_property_map = custom_property_map or {}
 
     id_to_row = {}
     insertion_order = []
     for issue in issues:
         row = generate_table_row(issue, columns)
+        if custom_keys:
+            cells = custom_property_map.get(issue["id"], {})
+            row += [cells.get(key, "") for key in custom_keys]
         row_id = row[id_idx] if id_idx is not None else id(row)
         existing = id_to_row.get(row_id)
         if existing is None:
@@ -612,8 +655,11 @@ def issue_export_task(
             order_by_param=order_by_param,
         )
 
+        # Custom property columns (workspace-specific, e.g. heineken) always
+        # go at the end, after whatever the display-properties picker selected.
+        custom_keys = ALLOWED_CUSTOM_PROPERTY_WORKSPACE_MAP.get(slug, [])
         columns = resolve_export_columns(display_properties)
-        header = [r.label for r in columns]
+        header = [r.label for r in columns] + list(custom_keys)
 
         # Cap the export to EXPORT_ROW_LIMIT distinct issues *before* the
         # M2M-joined .values() fan-out. We slice the already-ordered base
@@ -630,6 +676,8 @@ def issue_export_task(
             base_qs.filter(id__in=capped_ids), columns
         )
 
+        custom_property_map = fetch_custom_property_map(capped_ids, custom_keys)
+
         truncation_notice_row = (
             [
                 f"NOTE: Export truncated to the first {EXPORT_ROW_LIMIT} "
@@ -643,9 +691,15 @@ def issue_export_task(
         if multiple:
             for project_id in project_ids:
                 issues = workspace_issues.filter(project__id=project_id)
-                generate_csv(header, project_id, issues, files, columns)
+                generate_csv(
+                    header, project_id, issues, files, columns,
+                    custom_keys, custom_property_map,
+                )
         else:
-            generate_csv(header, workspace_id, workspace_issues, files, columns)
+            generate_csv(
+                header, workspace_id, workspace_issues, files, columns,
+                custom_keys, custom_property_map,
+            )
 
         # Prepend a single-cell truncation notice to every generated CSV.
         if truncation_notice_row:


### PR DESCRIPTION
## Summary
- Include workspace-specific custom properties (from `ALLOWED_CUSTOM_PROPERTY_WORKSPACE_MAP`, e.g. heineken's "Stays (in days)", "Approved Cost (in BRL)", "Invoice", etc.) as trailing columns in the issue CSV export.
- Values are fetched in a single extra query (`fetch_custom_property_map`) keyed by issue id — no join fan-out on top of the existing assignee/label fan-out.
- Typed values are rendered per populated column: string `value`, `int_value`, `bool_value` (Yes/No), `date_value` (same format as other date columns). Issues without a value get an empty cell; on duplicate keys the most recent row wins.
- Workspaces not in the map are unaffected — header and rows are unchanged for them.

## Testing
- Module compiles; behavior of `fetch_custom_property_map` unit-tested (typed rendering, newest-wins dedup, empty-input short-circuits).
- Recommend one QA export on a heineken dev workspace (`heineken-br1-dev`) to confirm stored `key` strings match the display names in the map exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)