### PR TITLE
fix: export completes when the presigned URL exceeds the url column limit (ISS-285485)

### DIFF
--- a/apiserver/plane/bgtasks/export_task.py
+++ b/apiserver/plane/bgtasks/export_task.py
@@ -234,9 +234,15 @@ def upload_to_s3(file_obj, workspace_id, token_id, slug, extension="zip"):
 
     # Update the exporter instance with the presigned url
     if presigned_url:
-        exporter_instance.url = presigned_url
         exporter_instance.status = "completed"
         exporter_instance.key = file_name
+        # URLs signed with role-session credentials (IRSA / task role) carry
+        # an X-Amz-Security-Token and blow past the url column's 800-char
+        # limit. The list endpoint re-signs a fresh URL from `key` on every
+        # request anyway, so only persist the URL when it fits.
+        exporter_instance.url = (
+            presigned_url if len(presigned_url) <= 800 else None
+        )
     else:
         exporter_instance.status = "failed"
 

--- a/apiserver/plane/bgtasks/exporter_expired_task.py
+++ b/apiserver/plane/bgtasks/exporter_expired_task.py
@@ -17,9 +17,11 @@ from plane.utils.s3_client import get_s3_client
 @shared_task
 def delete_old_s3_link():
     # Get a list of keys and IDs to process
+    # Completed exports are identified by `key` — `url` may be empty when the
+    # presigned URL was too long to persist (role-session credentials).
     expired_exporter_history = ExporterHistory.objects.filter(
-        Q(url__isnull=False)
-        & Q(created_at__lte=timezone.now() - timedelta(days=8))
+        Q(created_at__lte=timezone.now() - timedelta(days=8))
+        & (Q(url__isnull=False) | (Q(key__isnull=False) & ~Q(key="")))
     ).values_list("key", "id")
     if settings.USE_MINIO:
         s3 = get_s3_client(endpoint_url=settings.AWS_S3_ENDPOINT_URL)
@@ -38,4 +40,4 @@ def delete_old_s3_link():
                     Bucket=settings.AWS_STORAGE_BUCKET_NAME, Key=file_name
                 )
 
-        ExporterHistory.objects.filter(id=exporter_id).update(url=None)
+        ExporterHistory.objects.filter(id=exporter_id).update(url=None, key="")


### PR DESCRIPTION
## Root cause of the failed exports on plane demo

`reason` (exposed in #310) showed: `value too long for type character varying(800)`.

The S3 upload succeeds — but since the role-based auth migration (#305), presigned URLs are signed with session credentials and carry an `X-Amz-Security-Token`, pushing them to ~1,700 chars. Saving that into `ExporterHistory.url` (`varchar(800)`) throws, and the exception handler marks the export **failed** after a fully successful upload.

## Fix (no migration)

- Persist the presigned URL only when it fits the column; always persist `key`. The list endpoint already re-signs a fresh URL from `key` on every request, so downloads are unaffected (stored URLs were stale-by-design anyway).
- The 8-day expired-link cleanup now selects completed exports by `key` instead of `url__isnull=False`, and clears both `url` and `key` after deleting the S3 object.

## Verification

- Simulated a 1,700-char presigned URL through `upload_to_s3` locally → `status: completed`, `key` persisted, no crash.
- Full export pipeline verified locally against the heineken workspace (1,628 issues → correct 943-row CSV with display-properties-ordered custom columns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)