### PR TITLE
fix: assignee dropdown freezes on projects with very large member lists (ISS-292204)

### DIFF
--- a/apiserver/plane/app/views/project/member.py
+++ b/apiserver/plane/app/views/project/member.py
@@ -1,3 +1,6 @@
+# Django imports
+from django.db.models import Q
+
 # Third Party imports
 from rest_framework.response import Response
 from rest_framework import status
@@ -210,6 +213,34 @@ class ProjectMemberViewSet(BaseViewSet):
             member__is_bot=False,
             is_active=True,
         ).select_related("project", "member", "workspace")
+
+        # Opt-in server-side search and limit for large projects; without
+        # these params the full member list is returned as before.
+        search = request.query_params.get("search")
+        if search:
+            project_members = project_members.filter(
+                Q(member__display_name__icontains=search)
+                | Q(member__first_name__icontains=search)
+                | Q(member__last_name__icontains=search)
+            )
+
+        per_page = request.query_params.get("per_page")
+        if per_page:
+            try:
+                per_page = int(per_page)
+            except ValueError:
+                return Response(
+                    {"error": "Invalid per_page parameter."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            if per_page <= 0:
+                return Response(
+                    {"error": "Invalid per_page parameter."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            project_members = project_members.order_by(
+                "member__display_name"
+            )[:per_page]
 
         serializer = ProjectMemberRoleSerializer(
             project_members, fields=("id", "member", "role"), many=True

--- a/apiserver/plane/app/views/project/member.py
+++ b/apiserver/plane/app/views/project/member.py
@@ -218,11 +218,15 @@ class ProjectMemberViewSet(BaseViewSet):
         # these params the full member list is returned as before.
         search = request.query_params.get("search")
         if search:
-            project_members = project_members.filter(
-                Q(member__display_name__icontains=search)
-                | Q(member__first_name__icontains=search)
-                | Q(member__last_name__icontains=search)
-            )
+            # AND each whitespace-separated term across the name fields so
+            # multi-word queries like "john sm" match the way the client's
+            # concatenated-name filter does.
+            for term in search.split():
+                project_members = project_members.filter(
+                    Q(member__display_name__icontains=term)
+                    | Q(member__first_name__icontains=term)
+                    | Q(member__last_name__icontains=term)
+                )
 
         per_page = request.query_params.get("per_page")
         if per_page:

--- a/web/core/components/dropdowns/member/index.tsx
+++ b/web/core/components/dropdowns/member/index.tsx
@@ -174,6 +174,7 @@ export const MemberDropdown: React.FC<Props> = observer((props) => {
           projectId={projectId}
           placement={placement}
           referenceElement={referenceElement}
+          value={value}
         />
       )}
     </ComboDropDown>

--- a/web/core/components/dropdowns/member/member-options.tsx
+++ b/web/core/components/dropdowns/member/member-options.tsx
@@ -25,12 +25,22 @@ interface Props {
   referenceElement: HTMLButtonElement | null;
   placement: Placement | undefined;
   isOpen: boolean;
+  value?: string | string[] | null;
 }
 
+// maximum number of options rendered in the dropdown at once
+const OPTIONS_RENDER_LIMIT = 20;
+// minimum characters before the query is searched on the server
+const SERVER_SEARCH_MIN_CHARS = 3;
+// debounce interval for server search
+const SERVER_SEARCH_DEBOUNCE_MS = 300;
+
 export const MemberOptions: React.FC<Props> = observer((props: Props) => {
-  const { projectId, referenceElement, placement, isOpen, optionsClassName = "" } = props;
+  const { projectId, referenceElement, placement, isOpen, optionsClassName = "", value } = props;
   // states
   const [query, setQuery] = useState("");
+  const [searchedUserIds, setSearchedUserIds] = useState<string[] | null>(null);
+  const [isSearching, setIsSearching] = useState(false);
   const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
   // refs
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -39,7 +49,7 @@ export const MemberOptions: React.FC<Props> = observer((props: Props) => {
   const { workspaceSlug } = useParams();
   const {
     getUserDetails,
-    project: { getProjectMemberIds, fetchProjectMembers },
+    project: { getProjectMemberIds, searchProjectMembers },
     workspace: { workspaceMemberIds },
   } = useMember();
   const { data: currentUser } = useUser();
@@ -68,8 +78,41 @@ export const MemberOptions: React.FC<Props> = observer((props: Props) => {
 
   const memberIds = projectId ? getProjectMemberIds(projectId) : workspaceMemberIds;
   const onOpen = () => {
-    if (!memberIds && workspaceSlug && projectId) fetchProjectMembers(workspaceSlug.toString(), projectId);
+    if (!memberIds && workspaceSlug && projectId)
+      searchProjectMembers(workspaceSlug.toString(), projectId, { per_page: OPTIONS_RENDER_LIMIT });
   };
+
+  // server-side member search for project dropdowns, debounced and
+  // triggered only once the query is long enough
+  const trimmedQuery = query.trim();
+  useEffect(() => {
+    if (!workspaceSlug || !projectId || trimmedQuery.length < SERVER_SEARCH_MIN_CHARS) {
+      setSearchedUserIds(null);
+      setIsSearching(false);
+      return;
+    }
+    setIsSearching(true);
+    let cancelled = false;
+    const timer = setTimeout(() => {
+      searchProjectMembers(workspaceSlug.toString(), projectId, {
+        search: trimmedQuery,
+        per_page: OPTIONS_RENDER_LIMIT,
+      })
+        .then((userIds) => {
+          if (!cancelled) setSearchedUserIds(userIds);
+        })
+        .catch(() => {
+          if (!cancelled) setSearchedUserIds(null);
+        })
+        .finally(() => {
+          if (!cancelled) setIsSearching(false);
+        });
+    }, SERVER_SEARCH_DEBOUNCE_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [trimmedQuery, workspaceSlug, projectId, searchProjectMembers]);
 
   const searchInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (query !== "" && e.key === "Escape") {
@@ -78,12 +121,43 @@ export const MemberOptions: React.FC<Props> = observer((props: Props) => {
     }
   };
 
-  const options = memberIds?.map((userId) => {
+  const isServerSearchActive = !!projectId && searchedUserIds !== null;
+  const baseIds = isServerSearchActive ? searchedUserIds : memberIds;
+
+  // pin the currently selected member(s) to the top of the list
+  const selectedIds = Array.isArray(value) ? value : value ? [value] : [];
+  let optionIds = baseIds;
+  if (baseIds) {
+    if (isServerSearchActive) {
+      optionIds = [...baseIds].sort(
+        (a, b) => Number(selectedIds.includes(b)) - Number(selectedIds.includes(a))
+      );
+    } else {
+      optionIds = [
+        ...selectedIds.filter((userId) => getUserDetails(userId)),
+        ...baseIds.filter((userId) => !selectedIds.includes(userId)),
+      ];
+    }
+  }
+
+  // filter at the id level and only build option objects for the rendered
+  // slice, so a large member list never causes a heavy render
+  const queryLowerCase = query.toLowerCase();
+  const matchingIds =
+    isServerSearchActive || query === ""
+      ? optionIds
+      : optionIds?.filter((userId) => {
+          const userDetails = getUserDetails(userId);
+          return `${userDetails?.display_name} ${userDetails?.first_name} ${userDetails?.last_name}`
+            .toLowerCase()
+            .includes(queryLowerCase);
+        });
+
+  const visibleOptions = matchingIds?.slice(0, OPTIONS_RENDER_LIMIT).map((userId) => {
     const userDetails = getUserDetails(userId);
 
     return {
       value: userId,
-      query: `${userDetails?.display_name} ${userDetails?.first_name} ${userDetails?.last_name}`,
       content: (
         <div className="flex items-center gap-2">
           <Avatar name={userDetails?.display_name} src={getFileURL(userDetails?.avatar_url ?? "")} />
@@ -92,9 +166,6 @@ export const MemberOptions: React.FC<Props> = observer((props: Props) => {
       ),
     };
   });
-
-  const filteredOptions =
-    query === "" ? options : options?.filter((o) => o.query.toLowerCase().includes(query.toLowerCase()));
 
   return createPortal(
     <Combobox.Options data-prevent-outside-click static>
@@ -123,9 +194,11 @@ export const MemberOptions: React.FC<Props> = observer((props: Props) => {
           />
         </div>
         <div className="mt-2 max-h-48 space-y-1 overflow-y-scroll">
-          {filteredOptions ? (
-            filteredOptions.length > 0 ? (
-              filteredOptions.map((option) => (
+          {isSearching ? (
+            <p className="px-1.5 py-1 italic text-custom-text-400">{t("loading")}</p>
+          ) : visibleOptions ? (
+            visibleOptions.length > 0 ? (
+              visibleOptions.map((option) => (
                 <Combobox.Option
                   key={option.value}
                   value={option.value}

--- a/web/core/hooks/store/use-mention.ts
+++ b/web/core/hooks/store/use-mention.ts
@@ -22,16 +22,18 @@ export const useMention = ({ workspaceSlug, projectId, members, user }: Props) =
   const userRef = useRef<IUser | undefined>();
 
   const {
-    project: { fetchProjectMembers },
+    project: { searchProjectMembers },
   } = useMember();
 
   useEffect(() => {
     if (members) projectMembersRef.current = members;
     else {
       if (!workspaceSlug || !projectId) return;
-      fetchProjectMembers(workspaceSlug.toString(), projectId.toString());
+      // load a capped member list for mention suggestions instead of the
+      // full project member list
+      searchProjectMembers(workspaceSlug.toString(), projectId.toString(), { per_page: 20 });
     }
-  }, [fetchProjectMembers, members, projectId, workspaceSlug]);
+  }, [searchProjectMembers, members, projectId, workspaceSlug]);
 
   useEffect(() => {
     if (userRef) userRef.current = user;
@@ -71,7 +73,8 @@ export const useMention = ({ workspaceSlug, projectId, members, user }: Props) =
   const mentionSuggestions = async (): Promise<IMentionSuggestion[]> => {
     if (members && projectMembersRef.current && projectMembersRef.current.length > 0) {
       // If data is already available, return it immediately
-      return projectMembersRef.current.map((memberDetails) => ({
+      // cap the suggestions so the mention popup never renders a huge list
+      return projectMembersRef.current.slice(0, 20).map((memberDetails) => ({
         entity_name: "user_mention",
         entity_identifier: `${memberDetails?.id}`,
         id: `${memberDetails?.id}`,
@@ -84,7 +87,7 @@ export const useMention = ({ workspaceSlug, projectId, members, user }: Props) =
     } else {
       // Wait for data to be available
       const membersList = await waitForData();
-      return membersList.map((memberDetails) => ({
+      return membersList.slice(0, 20).map((memberDetails) => ({
         entity_name: "user_mention",
         entity_identifier: `${memberDetails?.id}`,
         id: `${memberDetails?.id}`,

--- a/web/core/services/project/project-member.service.ts
+++ b/web/core/services/project/project-member.service.ts
@@ -9,8 +9,12 @@ export class ProjectMemberService extends APIService {
     super(API_BASE_URL);
   }
 
-  async fetchProjectMembers(workspaceSlug: string, projectId: string): Promise<IProjectMembership[]> {
-    return this.get(`/api/workspaces/${workspaceSlug}/projects/${projectId}/members/`)
+  async fetchProjectMembers(
+    workspaceSlug: string,
+    projectId: string,
+    params?: { search?: string; per_page?: number }
+  ): Promise<IProjectMembership[]> {
+    return this.get(`/api/workspaces/${workspaceSlug}/projects/${projectId}/members/`, { params })
       .then((response) => response?.data)
       .catch((error) => {
         throw error?.response?.data;

--- a/web/core/store/issue/issue-details/sub_issues.store.ts
+++ b/web/core/store/issue/issue-details/sub_issues.store.ts
@@ -324,10 +324,11 @@ export class IssueSubIssuesStore implements IIssueSubIssuesStore {
       for (const projectId of projectIds) {
         // fetching other project states
         this.rootIssueDetailStore.rootIssueStore.rootStore.state.fetchProjectStates(workspaceSlug, projectId);
-        // fetching other project members
-        this.rootIssueDetailStore.rootIssueStore.rootStore.memberRoot.project.fetchProjectMembers(
+        // fetching other project members (capped — dropdowns search the rest server-side)
+        this.rootIssueDetailStore.rootIssueStore.rootStore.memberRoot.project.searchProjectMembers(
           workspaceSlug,
-          projectId
+          projectId,
+          { per_page: 20 }
         );
         // fetching other project labels
         this.rootIssueDetailStore.rootIssueStore.rootStore.label.fetchProjectLabels(workspaceSlug, projectId);

--- a/web/core/store/member/project-member.store.ts
+++ b/web/core/store/member/project-member.store.ts
@@ -40,6 +40,11 @@ export interface IProjectMemberStore {
   getProjectMemberIds: (projectId: string) => string[] | null;
   // fetch actions
   fetchProjectMembers: (workspaceSlug: string, projectId: string) => Promise<IProjectMembership[]>;
+  searchProjectMembers: (
+    workspaceSlug: string,
+    projectId: string,
+    params?: { search?: string; per_page?: number }
+  ) => Promise<string[]>;
   // bulk operation actions
   bulkAddMembersToProject: (
     workspaceSlug: string,
@@ -77,6 +82,7 @@ export class ProjectMemberStore implements IProjectMemberStore {
       projectMemberIds: computed,
       // actions
       fetchProjectMembers: action,
+      searchProjectMembers: action,
       bulkAddMembersToProject: action,
       updateMember: action,
       removeMemberFromProject: action,
@@ -152,6 +158,26 @@ export class ProjectMemberStore implements IProjectMemberStore {
         });
       });
       return response;
+    });
+
+  /**
+   * @description search project members on the server, merge them into the store and return the matching user ids
+   * @param workspaceSlug
+   * @param projectId
+   * @param params search term and/or result limit
+   */
+  searchProjectMembers = async (
+    workspaceSlug: string,
+    projectId: string,
+    params?: { search?: string; per_page?: number }
+  ) =>
+    await this.projectMemberService.fetchProjectMembers(workspaceSlug, projectId, params).then((response) => {
+      runInAction(() => {
+        response.forEach((member) => {
+          set(this.projectMemberMap, [projectId, member.member], member);
+        });
+      });
+      return response.map((membership) => membership.member);
     });
 
   /**


### PR DESCRIPTION
## Issue
ISS-292204 (bug)

## Problem
On projects with very large member lists (~16k members), opening the assignee dropdown — or simply opening a ticket from All Issues — froze the entire frontend for several seconds.

Root cause, in order of impact:
1. The members endpoint (`GET /api/workspaces/:slug/projects/:id/members/`) returned the full member list with no pagination (~2–3 MB JSON).
2. The dropdown rendered **every** member as a DOM node (~16k `Combobox.Option` rows) in one synchronous pass — this DOM render was the actual freeze.
3. Ticket-open paths (@-mention system, cross-project sub-issues) triggered the same full fetch even outside project pages.

## Fix
**Backend — backward compatible**
- `ProjectMemberViewSet.list` now accepts optional `?search=` (case-insensitive substring on display/first/last name) and `?per_page=` params. Without params the response is byte-identical to before, so all existing callers (project settings, project wrapper, mobile) are unaffected.

**Frontend — everything member-related processes at most 20 entries at a time**
- Assignee dropdown: fetches 20 on open, renders max 20 options (filtering happens at the id level before any JSX is built), and debounce-searches the server once the query reaches 3 characters — so all members remain findable.
- Currently selected assignees are pinned to the top of the option list.
- @-mention and sub-issue member fetches on ticket open are capped at `per_page=20`; mention suggestions are capped at 20 so the popup never renders an unbounded list.

## Known trade-offs (deliberate, kept for minimal scope)
- @-mention suggestions offer the first 20 project members only (no server search in mentions).
- Project pages still bulk-fetch the full member list via the project wrapper (settings/filters depend on it) — the freeze cannot recur since rendering is capped, but the payload remains; tracked as a follow-up.

## Testing
- `tsc --noEmit` clean on `web`; backend view compiles.
- Manually verified `?per_page=20` returns exactly 20 rows (large production-like workspace) and `?search=` returns matching members.
- Verified dropdown opens instantly with 20 rows, 3+ char typing hits `/members/?search=...&per_page=20`, selected assignee appears first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)