### PR TITLE
[ISS-292928] fix: derive start/target date from datetime fields at ticket creation

### DIFF
--- a/apiserver/plane/api/serializers/issue.py
+++ b/apiserver/plane/api/serializers/issue.py
@@ -2,6 +2,7 @@
 from django.utils import timezone
 from lxml import html
 import uuid
+import zoneinfo
 
 #  Third party imports
 from rest_framework import serializers
@@ -17,6 +18,7 @@ from plane.db.models import (
     IssueLabel,
     IssueLink,
     Label,
+    Project,
     ProjectMember,
     State,
     User,
@@ -104,6 +106,27 @@ class IssueSerializer(BaseSerializer):
         ]
     
     def validate(self, data):
+        # The date-only fields must match the calendar date of the datetime
+        # fields in the project's timezone; callers computing them in UTC
+        # produce off-by-one dates for timezones ahead of UTC.
+        project_tz = None
+        if data.get("start_date_time") or data.get("target_date_time"):
+            project = Project.objects.filter(
+                pk=self.context.get("project_id")
+            ).first()
+            if project and project.timezone and project.timezone != "UTC":
+                project_tz = zoneinfo.ZoneInfo(project.timezone)
+        if data.get("start_date_time") is not None:
+            dt = data["start_date_time"]
+            data["start_date"] = (
+                dt.astimezone(project_tz).date() if project_tz else dt.date()
+            )
+        if data.get("target_date_time") is not None:
+            dt = data["target_date_time"]
+            data["target_date"] = (
+                dt.astimezone(project_tz).date() if project_tz else dt.date()
+            )
+
         if (
             data.get("start_date", None) is not None
             and data.get("target_date", None) is not None


### PR DESCRIPTION
## Bug

**ISS-292928** — Tickets created in the morning in timezones ahead of UTC (e.g. Sydney, UTC+10) are stored with the previous day's start/due date. Example: a rider ticket created 1 Sept 07:09 AEST stored `start_date = 2026-08-31` while `start_date_time = 2026-09-01T07:09+10:00` was correct.

## Root cause

The ticketing-tool integration computes the date-only `start_date`/`target_date` strings from `datetime.now(UTC)` — the UTC calendar day — while the tz-aware `*_date_time` fields remain convertible and correct. Plane stored the inconsistent pair as sent.

## Fix

Resolve the dates at write time, in the external API `IssueSerializer.validate()` (runs on every create/update): when `start_date_time`/`target_date_time` are present, derive `start_date`/`target_date` from them in the **project's timezone**, ignoring the caller's UTC-computed date strings. The stored dates are then correct everywhere they're consumed — UI display, filters, grouping, sorting, overdue queries, and exports — with no frontend or export changes needed.

- Generic across all orgs/locations: the per-org knob is the existing `Project.timezone` field, set once per project
- Projects on the default UTC timezone fall back to the datetime's own offset — zero behavior change until the timezone is set
- Requests without datetime fields (e.g. plain date-picker payloads from the web app) are untouched
- No ticketing-tool changes required; inconsistent date/datetime pairs can no longer be stored

## Rollout

1. Deploy, then set each project's timezone, e.g. `Project.objects.filter(id='947ea4c9-a406-4212-a2d7-03cfd1646082').update(timezone='Australia/Sydney')`
2. One-off backfill for existing rows so old tickets display and filter correctly: `UPDATE issues SET start_date = (start_date_time AT TIME ZONE 'Australia/Sydney')::date WHERE start_date_time IS NOT NULL AND start_date IS DISTINCT FROM (start_date_time AT TIME ZONE 'Australia/Sydney')::date;` (same for `target_date`)

## Verification

Replayed the reported ticket's timestamps through the new logic: project tz `Australia/Sydney` → `start_date = 2026-09-01` (correct); project tz `UTC` → `2026-08-31` (unchanged legacy behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)